### PR TITLE
채용공고 페이지 수정 / job_item_layout 수정 (채용중/마감) / 데이터 변경 / activity_job 레이아…

### DIFF
--- a/app/src/main/java/com/example/ssary/JobsAdapter.java
+++ b/app/src/main/java/com/example/ssary/JobsAdapter.java
@@ -2,6 +2,7 @@ package com.example.ssary;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -53,28 +54,40 @@ public class JobsAdapter extends RecyclerView.Adapter<JobsAdapter.JobViewHolder>
         Job job = jobsList.get(position);
         holder.companyName.setText("# " + job.getCompanyName());
 
-        // 마감 여부에 따른 텍스트 색상 설정
+        // Drawable 설정을 위한 GradientDrawable 객체 생성
+        GradientDrawable backgroundDrawable = (GradientDrawable) context.getResources()
+                .getDrawable(R.drawable.company_item_background).mutate();
+
         try {
             Date endDate = sdf.parse(job.getEndDate());
             Date today = new Date();
 
             if (endDate != null && endDate.before(today)) {
+                // 마감된 공고: 회색 배경, 회색 텍스트
+                backgroundDrawable.setColor(context.getResources().getColor(R.color.lightgray));
                 holder.companyName.setTextColor(Color.GRAY);
             } else {
-                holder.companyName.setTextColor(Color.BLACK);
+                // 진행 중인 공고: 파란색 배경, 흰색 텍스트
+                backgroundDrawable.setColor(context.getResources().getColor(R.color.blue));
+                holder.companyName.setTextColor(Color.WHITE);
             }
         } catch (ParseException e) {
             e.printStackTrace();
+            backgroundDrawable.setColor(context.getResources().getColor(R.color.lightgray));
             holder.companyName.setTextColor(Color.BLACK);
         }
+
+        // 최종적으로 TextView에 배경 설정
+        holder.companyName.setBackground(backgroundDrawable);
 
         // 아이템 클릭 시 리스너 호출
         holder.itemView.setOnClickListener(v -> {
             if (onItemClickListener != null) {
-                onItemClickListener.onItemClick(job); // 리스너의 onItemClick 메서드 호출
+                onItemClickListener.onItemClick(job);
             }
         });
     }
+
 
     @Override
     public int getItemCount() {

--- a/app/src/main/res/drawable/company_item_background.xml
+++ b/app/src/main/res/drawable/company_item_background.xml
@@ -2,7 +2,4 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/lightgray" /> <!-- 배경색을 원하는 색상으로 설정하세요 -->
     <corners android:radius="16dp" /> <!-- 둥근 모서리 설정 -->
-    <stroke
-        android:width="1dp"
-        android:color="@color/lightgray" /> <!-- 테두리 색상과 두께 설정 -->
 </shape>

--- a/app/src/main/res/layout/activity_job.xml
+++ b/app/src/main/res/layout/activity_job.xml
@@ -17,6 +17,11 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <!-- 채용 공고 텍스트 -->
+
+    <!-- 검색 아이콘 -->
+
+    <!-- 검색 입력 필드 -->
+
     <TextView
         android:id="@+id/joblist"
         android:layout_width="wrap_content"
@@ -28,8 +33,33 @@
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@id/back"
         app:layout_constraintStart_toEndOf="@id/back"
-        app:layout_constraintTop_toTopOf="@id/back"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintTop_toTopOf="@id/back" />
+
+    <ImageView
+        android:id="@+id/searchIcon"
+        android:layout_width="26dp"
+        android:layout_height="26dp"
+        android:layout_marginStart="116dp"
+        android:clickable="true"
+        android:contentDescription="Search"
+        android:src="@drawable/ic_search"
+        app:layout_constraintBottom_toBottomOf="@id/joblist"
+        app:layout_constraintStart_toEndOf="@id/joblist"
+        app:layout_constraintTop_toTopOf="@id/joblist"
+        app:layout_constraintVertical_bias="0.833" />
+
+    <EditText
+        android:id="@+id/searchEditText"
+        android:layout_width="0dp"
+        android:layout_height="42dp"
+        android:layout_marginTop="8dp"
+        android:hint="검색어를 입력하세요."
+        android:visibility="gone"
+        android:padding="8dp"
+        android:background="@color/lightgray"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/joblist" />
 
     <!-- "채용 중인 공고만 보기" 체크박스 -->
     <CheckBox
@@ -41,67 +71,19 @@
         android:textSize="16sp"
         android:minWidth="48dp"
         android:minHeight="48dp"
-        app:layout_constraintTop_toBottomOf="@id/joblist"
+        app:layout_constraintTop_toBottomOf="@id/searchEditText"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginStart="16dp" />
 
     <!-- RecyclerView 설정 -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview"
-        android:layout_width="410dp"
-        android:layout_height="586dp"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         android:padding="0.5dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/checkbox_only_active"
-        app:layout_constraintVertical_bias="0.065" />
-    <!-- 다음 페이지 버튼 -->
-    <ImageView
-        android:id="@+id/next_page_button"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginEnd="16dp"
-        android:contentDescription="다음 페이지 버튼"
-        android:src="@drawable/ic_right"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/recyclerview" />
-
-    <!-- 이전 페이지 버튼 -->
-    <ImageView
-        android:id="@+id/prev_page_button"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginStart="13dp"
-        android:contentDescription="이전 페이지 버튼"
-        android:src="@drawable/ic_left"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/recyclerview" />
-
-    <!-- 페이지 번호 표시 -->
-    <TextView
-        android:id="@+id/page_number"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:text="Page 1"
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-        app:layout_constraintTop_toBottomOf="@id/recyclerview"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
-
-    <!-- 검색 기능 -->
-    <SearchView
-        android:id="@+id/search"
-        android:layout_width="370dp"
-        android:layout_height="45dp"
-        android:queryHint="원하는 기업명 검색"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="15dp"
-        android:background="@color/lightgray"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/page_number"
-        app:layout_constraintHorizontal_bias="0.0"/>
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 작업 내용

> 채용공고 페이지 1개로 변경 ( 스크롤 사용 )
> job_item_layout 수정 ( 채용중 / 마감 색상 변경 )
> 채용 공고 데이터 변경
> activity_job (채용 공고 페이지 레이아웃 변경, 검색 위치 변경, page navigation 삭제)
 

## 트러블 슈팅

> firebase DB 내 JOB 제출시작일/마감일 날짜 형식과 jobadapter, jobactivity의 날짜 형식이 달라서 **"Skipped 117 frames! The application may be doing too much work on its main thread."** 같은 오류 발생 -> UI 렌더링 지연으로 메인 스레드에서 프레임 건너 뛰는 오류 -> 즉, 데이터가 불러와지지 않음.

> 해결: DB의 데이터 형식 변경 -> 원래 코드를 DB 형식에 맞춰 변경하는 게 수월하나, 가독성 면에서 YYYY-MM-DD 형식이 편할 것이라 생각해서 DB의 날짜 형식을 변경! 


## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 채용중 / 마감 background_color와 text color가 가독성이 있어 보이는지?
