### PR TITLE
[Feat]카테고리별 색상 설정 기능 추가

### DIFF
--- a/app/src/main/res/layout/activity_my_page.xml
+++ b/app/src/main/res/layout/activity_my_page.xml
@@ -81,8 +81,7 @@
         app:layout_constraintTop_toBottomOf="@id/categorySpinner"
         app:layout_constraintStart_toEndOf="@id/addCategoryButton"
         android:layout_marginTop="16dp"
-        android:layout_marginStart="8dp"
-        android:visibility="gone" />
+        android:layout_marginStart="8dp"/>
 
     <!-- 카테고리 삭제 버튼 -->
     <Button
@@ -95,6 +94,18 @@
         android:layout_marginTop="16dp"
         android:layout_marginStart="8dp"
         android:visibility="gone" />
+
+    <!-- 카테고리 색상 설정 버튼 -->
+    <Button
+        android:id="@+id/changeColorButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="카테고리 색상 설정"
+        app:layout_constraintTop_toBottomOf="@id/categorySpinner"
+        app:layout_constraintStart_toEndOf="@id/deleteCategoryButton"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="8dp"
+        android:visibility="gone"/>
 
     <!-- 글 작성 버튼 우측 하단 -->
     <Button


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호

## 작업 내용

>  카테고리 색상을 선택하고 저장하는 기능 추가
## 트러블 슈팅

1. 카테고리 색상이 기본적으로 없었음 - user정보에 카테고리 색상이 없어 작동하지 않음 -> 정보가 있는지 확인 후 없으면 기본값 추가
2. 색상 적용이 한타임씩 느림 - 색상이 적용되어 있는게 아니라 스크롤 하면 나중에 덧입혀짐 -> 카테고리 정보를 비동기식으로 입력받아 계속 업데이트 됨 -> 카테고리 값을 onCreate시 저장하고, 색상이 변경될 때 업데이트

### 스크린샷 (선택)
#### 글목록
<img width="226" alt="스크린샷 2024-12-18 오후 7 31 08" src="https://github.com/user-attachments/assets/3c8161fc-8b19-40b2-9576-748278d978c8" />

#### 특정 카테고리 선택 시
<img width="226" alt="스크린샷 2024-12-18 오후 7 31 36" src="https://github.com/user-attachments/assets/9278ce32-4e75-406c-a47e-fbb8a48155a7" />

#### 카테고리 색상 선택
<img width="226" alt="스크린샷 2024-12-18 오후 7 31 44" src="https://github.com/user-attachments/assets/0710f1ed-cb75-4b7f-8af9-547f11effc1a" />

## 리뷰 요구사항 (선택)

1. 카테고리 선택 시 카테고리 색상 설정 버튼이 추가되며 공간이 부족함 위치를 어디로 보내는 것이 좋을까요?
2. 색상 10개를 GPT의 선택으로 설정했는데, 가시성 등 확인 후 변경하는게 좋을 듯 한 색상이 있다면 알려주세요