### PR TITLE
파일 CRUD 프로세스 버그 해결

### DIFF
--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -92,14 +92,9 @@ public class MyExistTextActivity extends AppCompatActivity {
         documentId = intent.getStringExtra("documentId");
 
         categoryTextView.setText("카테고리: " + category);
-
         loadPostFromDataBase(documentId);
 
-        savePostButton.setOnClickListener(v -> {
-            updatePost();
-            enableEditing(false);
-            updateTitleEditTextConstraint(updatePostButton.getId());
-        });
+        savePostButton.setOnClickListener(v -> updatePost());
         updatePostButton.setOnClickListener(v -> {
             enableEditing(true);
 
@@ -356,8 +351,6 @@ public class MyExistTextActivity extends AppCompatActivity {
             uploadNewFileAndUpdatePost(updatedTitle, updatedContent);
         }
 
-        enableEditing(false);
-        updateTitleEditTextConstraint(updatePostButton.getId());
     }
 
     private void deleteFilesFromStorage(Runnable onComplete) {
@@ -394,6 +387,7 @@ public class MyExistTextActivity extends AppCompatActivity {
                 .update("title", title, "content", content, "files", files)
                 .addOnSuccessListener(aVoid -> {
                     Toast.makeText(this, "글이 수정되었습니다.", Toast.LENGTH_SHORT).show();
+                    finish();
                 })
                 .addOnFailureListener(e -> {
                     Toast.makeText(this, "글 수정에 실패했습니다.", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/example/ssary/MyNewTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyNewTextActivity.java
@@ -79,7 +79,7 @@ public class MyNewTextActivity extends AppCompatActivity {
         categorySpinner = findViewById(R.id.categorySpinner); // XML에 정의된 스피너
         categoryList = new ArrayList<>();
         categoryList.add("카테고리 선택"); // 기본 카테고리
-        loadCategoriesFromFirestore();
+        loadCategoriesFromDataBase();
 
         categoryAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, categoryList);
         categoryAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
@@ -123,7 +123,7 @@ public class MyNewTextActivity extends AppCompatActivity {
         });
     }
 
-    private void loadCategoriesFromFirestore() {
+    private void loadCategoriesFromDataBase() {
         db.collection("categories")
                 .get()
                 .addOnSuccessListener(queryDocumentSnapshots -> {
@@ -145,8 +145,6 @@ public class MyNewTextActivity extends AppCompatActivity {
                 })
                 .addOnFailureListener(e -> Toast.makeText(this, "카테고리를 불러오는 데 실패했습니다.", Toast.LENGTH_SHORT).show());
     }
-
-
 
     private void savePostToDataBase(String category, String title, String content, List<Map<String, String>> fileData) {
         Map<String, Object> post = new HashMap<>();


### PR DESCRIPTION
## 연관된 이슈

> resolve #27 

## 작업 내용

> 파일을 새로 추가하거나 삭제할 때, 스토리지에 정상적으로 추가 및 삭제되는지를 테스트하였습니다.
> 그 결과, 때에 따라 정상 작동 및 비정상 작동이 반복되어 그 원인을 분석하여 해결하였습니다.

## 트러블 슈팅

- 이전 상황: 불안정한 파일 CRUD 프로세스의 원인이 비동기 프로세스라고 판단되어 이러한 방향으로 해결 방법을 찾았습니다.
- 문제: 파일 삭제 비동기 프로세스의 문제가 아닌, 기존 파일이 재업로드되지 않아 발생했던 문제
    - 로직은 다음과 같음.
        1. 해당 글 클릭 시 -> loadPostFromDataBase() -> updateUploadedFilesUI() -> addFilesToContainer()
        2. 저장 버튼 클릭 -> updatePost() -> deleteFilesFromStorage() -> uploadNewFileAndUpdatePost() -> saveUpdatedPost()
    - 1번: 해당 글을 클릭했을 때, loadPostFromDataBase()라는 메서드를 통해서 DB에서 글 정보(제목, 내용, 파일URL)을 받아온다.
    - 2번: 파일의 CRUD가 발생하고, 저장 버튼을 누르면 2번 프로세스가 진행되는데, 저장이 완료되면 해당 글이 읽기 모드로 바뀌고, 해당 글에 머무른다(즉, 마이다이어리 페이지로 이동하지 않는다).
        - 이 상태에서 그대로 다시 수정 버튼을 눌러 파일을 수정하면 loadPostFromDataBase()는 호출되지 않아 기존 파일을 담는 리스트가 비어있게 된다. (마이다이어리에서 글을 클릭했을 때에만 loadPostFromDataBase()가 호출되도록 로직을 구성했음)
        - 따라서 기존 파일은 새 파일로 인식되어, 스토리지에 다시 업로드되어 중복되는 문제가 발생함.
        - 삭제 로직의 경우, 기존 파일이 삭제된 경우만 삭제 리스트에 담기 때문에 삭제 로직도 정상적으로 작동하지 않았던 것.
- 해결 방법
   - 사실 해당 글을 수정한 이후에도, 사용자가 읽기모드로 수정된 글에 머물게 한 이유는 수정된 글을 다시 확인할 수 있도록 사용자의 편의성을 증가시키기 위함이었음.
   - 하지만, 어차피 글 수정 버튼을 눌렀다면 이미 모든 것을 확인하고 수정 버튼을 눌렀기 때문에 글 수정이 완료되었을 때, 마이다이어리 페이지로 이동시키는 것이 편의성을 감소시키지 않는다고 판단.
   - 따라서 글을 수정했을 때 바로 마이다이어리 페이지로 이동할 수 있도록 하여 loadPostFromDataBase()을 정상적으로 동작시킬 수 있도록 함.

### 스크린샷 (선택)
![1](https://github.com/user-attachments/assets/973be64a-7eba-4891-ba4e-2534858dded2)
