### PR TITLE
마이 캘린더 페이지 내 채용공고 추가

### DIFF
--- a/app/src/main/res/layout/dialog_schedule_list.xml
+++ b/app/src/main/res/layout/dialog_schedule_list.xml
@@ -30,4 +30,27 @@
         android:layout_gravity="end"
         android:background="@null"
         android:contentDescription="Add Schedule" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#CCCCCC"
+        android:layout_marginVertical="16dp"/>
+
+    <TextView
+        android:id="@+id/tv_job_header"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="채용 공고"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp"/>
+
+    <!-- 채용공고 리스트 컨테이너 -->
+    <LinearLayout
+        android:id="@+id/jobListContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_job.xml
+++ b/app/src/main/res/layout/item_job.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- res/layout/item_job.xml -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="8dp"
+    android:gravity="center_vertical"
+    android:background="?android:attr/selectableItemBackground">
+
+    <ImageView
+        android:id="@+id/ivStarIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/star_full"
+        android:contentDescription="Favorite Icon" />
+
+    <TextView
+        android:id="@+id/tvJobTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="8dp"
+        android:text="Job Title"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/tvJobLink"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="공고 페이지 >"
+        android:textColor="#888888"
+        android:textSize="14sp" />
+</LinearLayout>


### PR DESCRIPTION
## 연관된 이슈

> resolved #29 #32 

## 작업 내용

> 1. 사용자 채용공고 즐겨찾기로 저장된 내역을 불러와 마이 캘린더 dialog에 추가했습니다.
> 2. 마이캘린더 dialog에서 즐겨찾기 버튼 클릭 시 즐겨찾기 삭제 및 UI 업데이트를 추가했습니다.
> 3. item_job 레이아웃을 설계했습니다.
> 4. 가독성을 위해 해당 날짜에 마감되는 채용 공고가 없을 시, 채용 공고 관련 내용이 dialog에서 보이지 않도록 설정하였습니다.
> 5. 선택된 날짜의 형식과 제출 마감일 날짜 형식을 통일 시켰습니다.

## 트러블 슈팅

> 데이터가 불러와지지 않는 문제 

1. 문제점: String userUID = FirebaseAuth.getInstance().getCurrentUser().getUid();
    db.collection("favorites").whereEqualTo("userUID", userUID) <- 해당 코드로 firestore 내 저장된 데이터를 불러오려고 하고 있었음.

2. 해결:  DatabaseReference favoritesRef = FirebaseDatabase.getInstance().getReference("favorites").child(userUID); <- 해당 코드로 바꿔주어 firebase realtime database로 연결하여 제대로 데이터를 불러오도록 함.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f9da6edb-143d-4daf-b8de-2500f6b57447)