### PR TITLE
캘린더 일정 CRUD 완성

### DIFF
--- a/app/src/main/res/layout/dialog_schedule_list.xml
+++ b/app/src/main/res/layout/dialog_schedule_list.xml
@@ -7,14 +7,32 @@
     android:padding="16dp"
     android:background="@drawable/dialog_background">
 
-    <TextView
-        android:id="@+id/tvSelectedDate"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="날짜"
-        android:textSize="18sp"
-        android:textStyle="bold" />
+        android:orientation="horizontal">
 
+        <TextView
+            android:id="@+id/tvSelectedDate"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:text="날짜"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <ImageButton
+            android:id="@+id/btnAddSchedule"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:src="@drawable/ic_plus_button"
+            android:scaleType="fitCenter"
+            android:background="@null"
+            android:contentDescription="Add Schedule" />
+    </LinearLayout>
+
+    <!-- 일정 리스트 컨테이너 -->
     <LinearLayout
         android:id="@+id/scheduleListContainer"
         android:layout_width="match_parent"
@@ -22,21 +40,12 @@
         android:orientation="vertical"
         android:layout_marginTop="8dp" />
 
-    <ImageButton
-        android:id="@+id/btnAddSchedule"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:src="@drawable/ic_plus_button"
-        android:layout_gravity="end"
-        android:background="@null"
-        android:contentDescription="Add Schedule" />
-
     <View
         android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="#CCCCCC"
-        android:layout_marginVertical="16dp"/>
+        android:layout_marginVertical="16dp" />
 
     <TextView
         android:id="@+id/tv_job_header"
@@ -45,7 +54,7 @@
         android:text="채용 공고"
         android:textSize="18sp"
         android:textStyle="bold"
-        android:layout_marginBottom="8dp"/>
+        android:layout_marginBottom="8dp" />
 
     <!-- 채용공고 리스트 컨테이너 -->
     <LinearLayout

--- a/app/src/main/res/layout/item_schedule.xml
+++ b/app/src/main/res/layout/item_schedule.xml
@@ -12,18 +12,24 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:text="일정 내용"
-        android:textSize="14sp" />
+        android:textSize="16sp" />
 
     <Button
         android:id="@+id/btnEdit"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="수정" />
+        android:layout_width="60dp"
+        android:layout_height="40dp"
+        android:backgroundTint="#FFC107"
+        android:text="수정"
+        android:textColor="@android:color/white"
+        android:textSize="14sp" />
 
     <Button
         android:id="@+id/btnDelete"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="60dp"
+        android:layout_height="40dp"
+        android:backgroundTint="#F44336"
         android:text="삭제"
-        android:layout_marginStart="8dp" />
+        android:textColor="@android:color/white"
+        android:layout_marginStart="8dp"
+        android:textSize="14sp" />
 </LinearLayout>


### PR DESCRIPTION
## 연관된 이슈

#26 캘린더 스케줄 CRUD 수정 - 완료

## 작업 내용

- 일정 CREATE
    - DB 저장 방식 변경(Firebase 고유 키 - 시간순)
    - 추후에 우선순위 변경 시 수정 가능하도록 order 필드 저장
- 일정 READ
    - 즐겨찾기 공간을 고려하여 날짜별 dialog에서 일정 추가 버튼의 위치를 우상단으로 이동
- 일정 UPDATE
    - 추가적인 수정 페이지 이동 없이 즉시 수정 가능하도록 구현
- 일정 DELETE
    - 삭제 버튼 클릭 시 삭제 여부 확인 alert 기능 구현

## 트러블 슈팅

1. 일정 추가 로직 오류
- 문제점 : 일정이 여러 개 일 경우, 중간 일정 삭제 후 일정 추가 시, 기존 일정 덮어씌워지는 오류
예시) 1, 2, 3번 일정 존재할 때, 2번 일정 삭제 후 추가 일정 등록 시 3번 일정이 덮어씌워짐
- 해결 : Firebase 고유 키를 사용하여 저장하는 방식으로 시간순 저장 및 덮어씌워질 수 없도록 수정

### 스크린샷

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/99eff40a-a7a0-4214-b4f5-5146d82bf782" width="200"></td>
    <td><img src="https://github.com/user-attachments/assets/7bf6f563-92d0-495e-8fc7-e46caa838aa5" width="200"></td>
    <td><img src="https://github.com/user-attachments/assets/d04a1690-189c-4f73-9bf5-0104fc3f5efc" width="200"></td>
  </tr>
</table>

## 기타 의견

- 일정 순서 변경은 우선 보류하겠습니다.
