### PR TITLE
bug: Ellipsis Truncation

### DIFF
--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -44,6 +44,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -352,7 +353,9 @@ public class MyExistTextActivity extends AppCompatActivity {
             View fileItemView = LayoutInflater.from(this).inflate(R.layout.my_exist_text_uploaded_file, uploadedFileContainer, false);
 
             TextView fileTextView = fileItemView.findViewById(R.id.uploadedFileTextView);
-            fileTextView.setText(fileName);
+
+            String displayName = truncateFileName(fileName);
+            fileTextView.setText(displayName);
             fileTextView.setOnClickListener(v -> openFile(fileUri));
 
             ImageView downloadFileButton = fileItemView.findViewById(R.id.downloadFileButton);
@@ -386,6 +389,23 @@ public class MyExistTextActivity extends AppCompatActivity {
 
             uploadedFileContainer.addView(fileItemView);
         }
+    }
+
+    // 파일 이름을 원하는 길이로 줄이는 메서드
+    private String truncateFileName(String fileName) {
+        BreakIterator charIterator = BreakIterator.getCharacterInstance();
+        charIterator.setText(fileName);
+        int maxLength = 40;
+
+        int endIndex = 0;
+        int count = 0;
+
+        while (charIterator.next() != BreakIterator.DONE) {
+            if (++count > maxLength) break;
+            endIndex = charIterator.current();
+        }
+
+        return count > maxLength ? fileName.substring(0, endIndex) + "..." : fileName;
     }
 
     // HTML 콘텐츠를 Spannable로 변환

--- a/app/src/main/java/com/example/ssary/MyNewTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyNewTextActivity.java
@@ -33,6 +33,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -292,7 +293,9 @@ public class MyNewTextActivity extends AppCompatActivity {
             View fileItemView = LayoutInflater.from(this).inflate(R.layout.my_new_text_uploaded_file, uploadedFileContainer, false);
 
             TextView fileTextView = fileItemView.findViewById(R.id.uploadedFileTextView);
-            fileTextView.setText(fileName);
+
+            String displayName = truncateFileName(fileName);
+            fileTextView.setText(displayName);
             fileTextView.setOnClickListener(v -> openFile(fileUri));
 
             ImageView deleteFileButton = fileItemView.findViewById(R.id.deleteFileButton);
@@ -314,6 +317,23 @@ public class MyNewTextActivity extends AppCompatActivity {
         }
 
         uploadedFileContainer.setVisibility(fileUris.isEmpty() ? View.GONE : View.VISIBLE);
+    }
+
+    // 파일 이름을 원하는 길이로 줄이는 메서드
+    private String truncateFileName(String fileName) {
+        BreakIterator charIterator = BreakIterator.getCharacterInstance();
+        charIterator.setText(fileName);
+        int maxLength = 40;
+
+        int endIndex = 0;
+        int count = 0;
+
+        while (charIterator.next() != BreakIterator.DONE) {
+            if (++count > maxLength) break;
+            endIndex = charIterator.current();
+        }
+
+        return count > maxLength ? fileName.substring(0, endIndex) + "..." : fileName;
     }
 
     // 파일 이름을 클릭하면 파일을 열 수 있도록 Intent 실행


### PR DESCRIPTION
## 연관된 이슈

> #39 

## 작업 내용

> 파일 이름이 너무 길어져, UI의 너비를 초과하는 문제를 Ellipsis Truncation으로 해결하였습니다.
> ※ Ellipsis Truncation: 텍스트가 지정된 공간을 초과할 경우, 텍스트의 일부를 잘라내고 …을 추가하여 줄이는 방식

## 트러블 슈팅

- **문제점**
  - 파일 이름이 특정 길이를 초과하면 "..." 처리를 통해, 파일 이름이 스마트폰의 화면 너비를 초과하는 문제를 해결하려고 함.
  - 하지만 파일 이름의 길이를 사용하면, 한글은 자음과 모음 단위로 계산되기 때문에 영어 기준으로 적절한 길이를 선정하더라도, 한글 파일 이름은 과도하게 블라인드 처리됨.
  - 한글은 UTF-16으로 인코딩되어 내부적으로 자음과 모음이 개별 코드 포인트로 표현됨.

- **해결 접근**: `BreakIterator.getCharacterInstance()`
  - `BreakIterator` 클래스의 `getCharacterInstance()`를 활용하여 한글 경계 규칙을 적용, 자음/모음을 결합된 한 글자로 처리함.

- **개념 정리**

  - BreakIterator
    - Java에서 텍스트 경계를 탐지하기 위한 클래스.
    - 주로 사람이 이해하는 논리적 단위(문자, 단어, 문장 등)로 나누는 데 사용.

  - BreakIterator.getCharacterInstance()
    - 텍스트를 문자(Character) 단위로 분리.
    - 내부적으로 Unicode Text Segmentation 알고리즘 사용 → 경계를 탐지.
    - Unicode 표준에 기반한 Grapheme Cluster를 사용.

  - 동작 방식
    1. **Grapheme Cluster** (= 사람이 인식하는 "문자") 분석.
    2. 언어별 경계 규칙 적용 → 한국어에서는 자음/모음을 결합된 한 글자로 처리.


### 스크린샷 (선택)
![KakaoTalk_20241229_192228009](https://github.com/user-attachments/assets/edc7decb-5c2b-4544-89f0-2f780e5c2a59)
