### PR TITLE
이미지 삽입 추가 기능 (ver2)

### DIFF
--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -1197,31 +1197,31 @@ public class MyExistTextActivity extends AppCompatActivity {
         StringBuilder htmlContent = new StringBuilder();
         Editable text = contentEditText.getText();
 
-        // 이미지 데이터 정렬 (위치 기준)
-        imageData.sort(Comparator.comparingInt(a -> Integer.parseInt(a.get("imagePosition"))));
+        int currentIndex = 0;
 
-        int currentIndex = 0; // 텍스트의 현재 위치
-        int imageIndex = 0; // 이미지 데이터의 현재 인덱스
+        while (currentIndex < text.length()) {
+            ImageSpan[] imageSpans = text.getSpans(currentIndex, currentIndex + 1, ImageSpan.class);
 
-        while (currentIndex < text.length() || imageIndex < imageData.size()) {
-            int imagePosition = imageIndex < imageData.size()
-                    ? Integer.parseInt(imageData.get(imageIndex).get("imagePosition"))
-                    : Integer.MAX_VALUE;
+            if (imageSpans.length > 0) {
+                // 이미지 스팬이 있는 경우
+                ImageSpan imageSpan = imageSpans[0];
+                String imageUrl = imageSpan.getSource();
 
-            if (currentIndex < imagePosition) {
-                // 텍스트 처리
-                char ch = text.charAt(currentIndex++);
-                if (ch == '\n') {
-                    htmlContent.append("<br>"); // 개행 문자를 <br>로 변환
-                } else {
-                    htmlContent.append(processStyledCharacter(text, currentIndex - 1, ch));
-                }
-            } else {
-                Map<String, String> imageInfo = imageData.get(imageIndex++);
-                String imageUrl = imageInfo.get("imageUrl");
                 if (imageUrl != null && !imageUrl.isEmpty()) {
                     htmlContent.append("<img src=\"").append(imageUrl).append("\" />");
                 }
+
+                // 이미지 스팬의 끝 위치로 이동
+                currentIndex = text.getSpanEnd(imageSpan);
+            } else {
+                // 일반 텍스트 처리
+                char ch = text.charAt(currentIndex);
+                if (ch == '\n') {
+                    htmlContent.append("<br>");
+                } else {
+                    htmlContent.append(processStyledCharacter(text, currentIndex, ch));
+                }
+                currentIndex++;
             }
         }
 

--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -365,11 +365,6 @@ public class MyExistTextActivity extends AppCompatActivity {
         // 이미지 상태 복원
         manageDeletedAndExistedImages(state);
 
-        // UI에서 이미지 재삽입
-        for (int i = 0; i < curImageUris.size(); i++) {
-            insertImageAtPosition(curImageUris.get(i), curImagePositions.get(i));
-        }
-
         // 커서 위치 조정
         contentEditText.setSelection(state.text.length());
     }
@@ -403,24 +398,6 @@ public class MyExistTextActivity extends AppCompatActivity {
                     existedImagePositions.add(state.imagePositions.get(state.imageUris.indexOf(imageUri)));
                 }
             }
-        }
-    }
-
-    private void insertImageAtPosition(Uri imageUri, int position) {
-        try {
-            Drawable drawable = Drawable.createFromStream(
-                    getContentResolver().openInputStream(imageUri),
-                    null
-            );
-            assert drawable != null;
-            drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
-
-            Editable text = contentEditText.getText();
-            ImageSpan imageSpan = new ImageSpan(drawable, ImageSpan.ALIGN_BASELINE);
-            text.insert(position, " "); // 이미지 자리 확보
-            text.setSpan(imageSpan, position, position + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        } catch (Exception e) {
-            Toast.makeText(this, "이미지를 복원할 수 없습니다.", Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -624,10 +601,6 @@ public class MyExistTextActivity extends AppCompatActivity {
 
                         List<Map<String, String>> images = (List<Map<String, String>>) documentSnapshot.get("images");
                         if (images != null) {
-                            curImageUris.clear();
-                            curImageNames.clear();
-                            curImagePositions.clear();
-
                             existedImageUris.clear();
                             existedImageNames.clear();
                             existedImagePositions.clear();
@@ -651,6 +624,10 @@ public class MyExistTextActivity extends AppCompatActivity {
     }
 
     private void loadInitialState(CharSequence styledText, List<Uri> initialImageUris, List<String> initialImageNames, List<Integer> initialImagePositions) {
+        curImageUris.clear();
+        curImageNames.clear();
+        curImagePositions.clear();
+
         curImageUris.addAll(initialImageUris);
         curImageNames.addAll(initialImageNames);
         curImagePositions.addAll(initialImagePositions);

--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -337,7 +337,7 @@ public class MyExistTextActivity extends AppCompatActivity {
 
             // 상태 저장
             undoRedoManager.saveState(new UndoRedoManager.State(
-                    contentEditText.getText().toString(),
+                    new SpannableString(contentEditText.getText()),
                     curImageUris,
                     curImageNames,
                     curImagePositions
@@ -655,20 +655,27 @@ public class MyExistTextActivity extends AppCompatActivity {
         curImageNames.addAll(initialImageNames);
         curImagePositions.addAll(initialImagePositions);
 
-        // 이미지를 텍스트에 삽입
-        for (int i = 0; i < curImageUris.size(); i++) {
-            insertImageAtPosition(curImageUris.get(i), curImagePositions.get(i));
+        // UndoRedoManager에 초기 상태 저장
+        if (styledText instanceof Spannable) {
+            undoRedoManager.saveState(new UndoRedoManager.State(
+                    (Spannable) styledText,
+                    curImageUris,
+                    curImageNames,
+                    curImagePositions
+            ));
+        } else {
+            Spannable spannableText = new SpannableString(styledText);
+            undoRedoManager.saveState(new UndoRedoManager.State(
+                    spannableText,
+                    curImageUris,
+                    curImageNames,
+                    curImagePositions
+            ));
         }
 
-        // UndoRedoManager에 초기 상태 저장
-        undoRedoManager.saveState(new UndoRedoManager.State(
-                styledText,
-                curImageUris,
-                curImageNames,
-                curImagePositions
-        ));
+        isInitialAccess = false;
 
-        updateUndoRedoButtons(); // 초기 버튼 상태 업데이트
+        updateUndoRedoButtons();
     }
 
     // 업로드된 파일 목록을 UI에 갱신

--- a/app/src/main/java/com/example/ssary/MyNewTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyNewTextActivity.java
@@ -133,7 +133,7 @@ public class MyNewTextActivity extends AppCompatActivity {
                 if (!isUndoRedoAction) {
                     // UndoRedoManager에 현재 상태 저장
                     undoRedoManager.saveState(new UndoRedoManager.State(
-                            s.toString(), // 텍스트 내용
+                            new SpannableString(s),
                             new ArrayList<>(imageUris),
                             new ArrayList<>(imageNames),
                             new ArrayList<>(imagePositions)
@@ -223,7 +223,7 @@ public class MyNewTextActivity extends AppCompatActivity {
 
         // UndoRedoManager에 초기 상태 저장
         undoRedoManager.saveState(new UndoRedoManager.State(
-                "",
+                new SpannableString(""),
                 imageUris,
                 imageNames,
                 imagePositions
@@ -275,7 +275,7 @@ public class MyNewTextActivity extends AppCompatActivity {
 
             // 상태 저장
             undoRedoManager.saveState(new UndoRedoManager.State(
-                    contentEditText.getText().toString(),
+                    new SpannableString(contentEditText.getText()),
                     imageUris,
                     imageNames,
                     imagePositions

--- a/app/src/main/java/com/example/ssary/ui/theme/UndoRedoManager.java
+++ b/app/src/main/java/com/example/ssary/ui/theme/UndoRedoManager.java
@@ -1,6 +1,7 @@
 package com.example.ssary.ui.theme;
 
 import android.net.Uri;
+import android.text.Spannable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,12 +10,12 @@ import java.util.Stack;
 
 public class UndoRedoManager {
     public static class State {
-        public CharSequence text;
+        public Spannable text;
         public List<Uri> imageUris;
         public List<String> imageNames;
         public List<Integer> imagePositions;
 
-        public State(CharSequence text, List<Uri> imageUris, List<String> imageNames, List<Integer> imagePositions) {
+        public State(Spannable text, List<Uri> imageUris, List<String> imageNames, List<Integer> imagePositions) {
             this.text = text;
             this.imageUris = new ArrayList<>(imageUris);
             this.imageNames = new ArrayList<>(imageNames);
@@ -51,7 +52,7 @@ public class UndoRedoManager {
     }
 
     public boolean canUndo() {
-        return !undoStack.isEmpty();
+        return undoStack.size() > 1;
     }
 
     public boolean canRedo() {


### PR DESCRIPTION
## 연관된 이슈

> #20

## 작업 내용

> 기존 게시글에서 백스페이스로 이미지가 삭제될 때, 이미지 삭제에 대한 다이얼로그를 띄우고, 삭제를 클릭했을 시, 각 리스트에 담아 관리하는 기능을 추가하였습니다.
> 기존에 백스페이스로 지운 이미지가 Storage에서 삭제되지 않는 문제를 해결하였습니다.

## 트러블 슈팅

1. 기존 게시글에서 불러온 게시글은 string으로 되어있고, 따라서 이미지는 객체 치환 문자로 저장되어 불러와지지 않는 문제가 있었습니다.
- 이러한 문제를 기존 글의 타입을 String에서 Spannable로 변경하여 해결하였습니다.
- UndoRedo의 글 정보도 Spannable로 관리함으로써 텍스트와 이미지에 대한 정보를 동시에 활용 가능하게 하였습니다.

## 리뷰 요구사항 (선택)

하지만 아직 큰 문제가 있습니다.
새 게시글을 작성하고, 이를 기존 게시글 형태로 확인하는 것은 문제가 없지만 기존 게시글에서 새로운 이미지를 삽입했을 때, 이미지 자체는 DB와 Storage에 업로드되지만 다시 해당 게시글을 방문했을 때, 새로운 이미지가 UI에 반영되지 않는 문제가 있습니다.
이것은 html 파일의 저장, 즉, convertToHtmlStyledContent() 메서드에 문제가 있는 것으로 판단되고 이를 수정할 필요가 있습니다.
