### PR TITLE
이미지 삽입 기능 완료

### DIFF
--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -284,11 +284,6 @@ public class MyExistTextActivity extends AppCompatActivity {
         }
     }
 
-
-
-
-
-
     // Undo/Redo 버튼 활성화 상태 업데이트
     private void updateUndoRedoButtons() {
         undoButton.setEnabled(undoRedoManager.canUndo());
@@ -321,16 +316,24 @@ public class MyExistTextActivity extends AppCompatActivity {
             // 커서 위치에 이미지 추가
             int position = contentEditText.getSelectionEnd();
             Editable text = contentEditText.getText();
-            ImageSpan imageSpan = new ImageSpan(drawable, ImageSpan.ALIGN_BASELINE);
-            text.insert(position, " "); // 이미지 자리 확보
+
+            // 객체 치환 문자 삽입
+            text.insert(position, "\uFFFC");
+            ImageSpan imageSpan = new ImageSpan(drawable, imageUri.toString(), ImageSpan.ALIGN_BASELINE);
             text.setSpan(imageSpan, position, position + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
-            // 업데이트 이미지
+            // 변경된 텍스트를 EditText에 반영
+            contentEditText.setText(text);
+
+            // 커서를 이미지 뒤로 이동
+            contentEditText.setSelection(position + 1);
+
+            // 업데이트 이미지 정보 저장
             updatedImageUris.add(imageUri);
             updatedImageNames.add(getFileName(imageUri));
             updatedImagePositions.add(position);
 
-            // 기존 + 업데이트 이미지
+            // 기존 + 업데이트 이미지 정보 저장
             curImageUris.add(imageUri);
             curImageNames.add(getFileName(imageUri));
             curImagePositions.add(position);
@@ -783,11 +786,7 @@ public class MyExistTextActivity extends AppCompatActivity {
         imageData.clear();
         fileData.clear();
 
-        if (!updatedImageUris.isEmpty()) {
-            uploadNewImagesToStorage(updatedCategory, updatedTitle);
-        } else {
-            completedTasks.incrementAndGet();
-        }
+        uploadNewImagesToStorage(updatedCategory, updatedTitle);
 
         if (!deletedImageUris.isEmpty()) {
             deleteImagesFromStorage(updatedCategory, updatedTitle);
@@ -795,11 +794,7 @@ public class MyExistTextActivity extends AppCompatActivity {
             completedTasks.incrementAndGet();
         }
 
-        if (!updatedFileUris.isEmpty()) {
-            uploadNewFilesToStorage(updatedCategory, updatedTitle);
-        } else {
-            completedTasks.incrementAndGet();
-        }
+        uploadNewFilesToStorage(updatedCategory, updatedTitle);
 
         if (!deletedFileUris.isEmpty()) {
             deleteFilesFromStorage(updatedCategory, updatedTitle);
@@ -870,35 +865,39 @@ public class MyExistTextActivity extends AppCompatActivity {
         }
 
         int totalUpdatedImages = updatedImageUris.size();
-        final int[] completedImages = {0};
 
-        for (int i = 0; i < totalUpdatedImages; i++) {
-            Uri updatedImageUri = updatedImageUris.get(i);
-            String updatedImageName = updatedImageNames.get(i);
-            int imagePosition = updatedImagePositions.get(i);
-            String updatedImageExtension = getFileExtension(updatedImageUri);
+        if (totalUpdatedImages != 0) {
+            final int[] completedImages = {0};
+            for (int i = 0; i < totalUpdatedImages; i++) {
+                Uri updatedImageUri = updatedImageUris.get(i);
+                String updatedImageName = updatedImageNames.get(i);
+                int imagePosition = updatedImagePositions.get(i);
+                String updatedImageExtension = getFileExtension(updatedImageUri);
 
-            String uniqueImageName = UUID.randomUUID().toString() + "_" + updatedImageName;
-            StorageReference fileRef = storage.getReference().child("images/" + uniqueImageName);
+                String uniqueImageName = UUID.randomUUID().toString() + "_" + updatedImageName;
+                StorageReference fileRef = storage.getReference().child("images/" + uniqueImageName);
 
-            fileRef.putFile(updatedImageUri)
-                    .addOnSuccessListener(taskSnapshot -> fileRef.getDownloadUrl().addOnSuccessListener(uri -> {
-                        Map<String, String> imageInfo = new HashMap<>();
-                        imageInfo.put("imageName", updatedImageName);
-                        imageInfo.put("imageExtension", updatedImageExtension != null ? updatedImageExtension : "unknown");
-                        imageInfo.put("imageUrl", uri.toString());
-                        imageInfo.put("imagePosition", String.valueOf(imagePosition));
-                        imageData.add(imageInfo);
+                fileRef.putFile(updatedImageUri)
+                        .addOnSuccessListener(taskSnapshot -> fileRef.getDownloadUrl().addOnSuccessListener(uri -> {
+                            Map<String, String> imageInfo = new HashMap<>();
+                            imageInfo.put("imageName", updatedImageName);
+                            imageInfo.put("imageExtension", updatedImageExtension != null ? updatedImageExtension : "unknown");
+                            imageInfo.put("imageUrl", uri.toString());
+                            imageInfo.put("imagePosition", String.valueOf(imagePosition));
+                            imageData.add(imageInfo);
 
-                        completedImages[0]++;
-                        if (completedImages[0] == totalUpdatedImages) {
-                            completedTasks.incrementAndGet();
-                            checkAndSavePost(category, title);
-                        }
-                    }))
-                    .addOnFailureListener(e -> {
-                        Toast.makeText(this, "이미지 업로드 실패: " + updatedImageName, Toast.LENGTH_SHORT).show();
-                    });
+                            completedImages[0]++;
+                            if (completedImages[0] == totalUpdatedImages) {
+                                completedTasks.incrementAndGet();
+                                checkAndSavePost(category, title);
+                            }
+                        }))
+                        .addOnFailureListener(e -> {
+                            Toast.makeText(this, "이미지 업로드 실패: " + updatedImageName, Toast.LENGTH_SHORT).show();
+                        });
+            }
+        } else {
+            completedTasks.incrementAndGet();
         }
     }
 
@@ -984,37 +983,41 @@ public class MyExistTextActivity extends AppCompatActivity {
         }
 
         int totalUpdatedFiles = updatedFileUris.size();
-        final int[] completedFiles = {0};
 
-        for (int i = 0; i < totalUpdatedFiles; i++) {
-            Uri updatedFileUri = updatedFileUris.get(i);
-            if (!isLocalUri(updatedFileUri)) {
-                Toast.makeText(this, "유효하지 않은 파일 URI: " + updatedFileUri, Toast.LENGTH_SHORT).show();
-                continue;
+        if (totalUpdatedFiles != 0) {
+            final int[] completedFiles = {0};
+            for (int i = 0; i < totalUpdatedFiles; i++) {
+                Uri updatedFileUri = updatedFileUris.get(i);
+                if (!isLocalUri(updatedFileUri)) {
+                    Toast.makeText(this, "유효하지 않은 파일 URI: " + updatedFileUri, Toast.LENGTH_SHORT).show();
+                    continue;
+                }
+
+                String updatedFileName = updatedFileNames.get(i);
+                String updatedFileExtension = getFileExtension(updatedFileUri);
+                String uniqueFileName = UUID.randomUUID().toString() + "_" + updatedFileName;
+                StorageReference fileRef = storage.getReference().child("files/" + uniqueFileName);
+
+                fileRef.putFile(updatedFileUri)
+                        .addOnSuccessListener(taskSnapshot -> fileRef.getDownloadUrl().addOnSuccessListener(uri -> {
+                            Map<String, String> fileInfo = new HashMap<>();
+                            fileInfo.put("fileName", updatedFileName);
+                            fileInfo.put("fileExtension", updatedFileExtension != null ? updatedFileExtension : "unknown");
+                            fileInfo.put("fileUrl", uri.toString());
+                            fileData.add(fileInfo);
+
+                            completedFiles[0]++;
+                            if (completedFiles[0] == totalUpdatedFiles) {
+                                completedTasks.incrementAndGet();
+                                checkAndSavePost(category, title);
+                            }
+                        }))
+                        .addOnFailureListener(e -> {
+                            Toast.makeText(this, "파일 업로드 실패: " + updatedFileName, Toast.LENGTH_SHORT).show();
+                        });
             }
-
-            String updatedFileName = updatedFileNames.get(i);
-            String updatedFileExtension = getFileExtension(updatedFileUri);
-            String uniqueFileName = UUID.randomUUID().toString() + "_" + updatedFileName;
-            StorageReference fileRef = storage.getReference().child("files/" + uniqueFileName);
-
-            fileRef.putFile(updatedFileUri)
-                    .addOnSuccessListener(taskSnapshot -> fileRef.getDownloadUrl().addOnSuccessListener(uri -> {
-                        Map<String, String> fileInfo = new HashMap<>();
-                        fileInfo.put("fileName", updatedFileName);
-                        fileInfo.put("fileExtension", updatedFileExtension != null ? updatedFileExtension : "unknown");
-                        fileInfo.put("fileUrl", uri.toString());
-                        fileData.add(fileInfo);
-
-                        completedFiles[0]++;
-                        if (completedFiles[0] == totalUpdatedFiles) {
-                            completedTasks.incrementAndGet();
-                            checkAndSavePost(category, title);
-                        }
-                    }))
-                    .addOnFailureListener(e -> {
-                        Toast.makeText(this, "파일 업로드 실패: " + updatedFileName, Toast.LENGTH_SHORT).show();
-                    });
+        } else {
+            completedTasks.incrementAndGet();
         }
     }
 
@@ -1174,31 +1177,37 @@ public class MyExistTextActivity extends AppCompatActivity {
         StringBuilder htmlContent = new StringBuilder();
         Editable text = contentEditText.getText();
 
-        int currentIndex = 0;
+        // 이미지 데이터 정렬 (위치 기준)
+        imageData.sort(Comparator.comparingInt(a -> Integer.parseInt(a.get("imagePosition"))));
 
-        while (currentIndex < text.length()) {
-            ImageSpan[] imageSpans = text.getSpans(currentIndex, currentIndex + 1, ImageSpan.class);
+        int currentIndex = 0; // 텍스트의 현재 위치
+        int imageIndex = 0;   // 이미지 데이터의 현재 인덱스
 
-            if (imageSpans.length > 0) {
-                // 이미지 스팬이 있는 경우
-                ImageSpan imageSpan = imageSpans[0];
-                String imageUrl = imageSpan.getSource();
+        while (currentIndex < text.length() || imageIndex < imageData.size()) {
+            if (imageIndex < imageData.size()) {
+                // 텍스트에서 객체 치환 문자("\uFFFC")를 찾음
+                if (currentIndex < text.length() && text.charAt(currentIndex) == '\uFFFC') {
+                    // 이미지 URL 삽입
+                    String imageUrl = imageData.get(imageIndex).get("imageUrl");
+                    if (imageUrl != null && !imageUrl.isEmpty()) {
+                        htmlContent.append("<img src=\"").append(imageUrl).append("\" />");
+                    }
 
-                if (imageUrl != null && !imageUrl.isEmpty()) {
-                    htmlContent.append("<img src=\"").append(imageUrl).append("\" />");
+                    // 다음 이미지로 이동
+                    imageIndex++;
+                    currentIndex++;
+                    continue;
                 }
+            }
 
-                // 이미지 스팬의 끝 위치로 이동
-                currentIndex = text.getSpanEnd(imageSpan);
-            } else {
-                // 일반 텍스트 처리
-                char ch = text.charAt(currentIndex);
+            // 일반 텍스트 처리
+            if (currentIndex < text.length()) {
+                char ch = text.charAt(currentIndex++);
                 if (ch == '\n') {
                     htmlContent.append("<br>");
                 } else {
-                    htmlContent.append(processStyledCharacter(text, currentIndex, ch));
+                    htmlContent.append(processStyledCharacter(text, currentIndex - 1, ch));
                 }
-                currentIndex++;
             }
         }
 


### PR DESCRIPTION
## 연관된 이슈

> resolve #20

## 작업 내용

> 이전 발생했던 이미지 추가와 삭제에 관련된 오류를 해결하였습니다.
> 추가로 이미지 위치 정보를 업데이트하는 기능도 추가하였습니다.
> 최종적으로 이미지 삽입 기능은 다음과 같습니다.
> 1. 이미지를 텍스트 타입으로 관리한다.
> 2. 백스페이스를 누르면 삭제 관련 다이얼로그가 나오고, "삭제" 시 리스트에서 해당 이미지 제거, "취소" 시 undo 실행
> 3. 이미지 뿐만 아니라 텍스트에 대해서 udno redo 수행

> 자세한 내용은 아래 트러블 슈팅 내용을 참고해주세요.

## 트러블 슈팅

1. 기존 게시글에서 이미지를 새로 추가하거나 삭제하고 저장했을 때, 다시 해당 글을 방문하면 객체 치환 문자로 표현되는 문제가 발생하였습니다. 이에 대한 문제는 다음과 같은 메서드에서 발생합니다.

**insertImageAtCursor() : 새로운 이미지를 추가하는 메서드**
**convertToHtmlStyledContent() : 최종적으로 "텍스트 + 이미지" 형태의 게시글을 html 형식으로 바꿔주는 메서드**

- 그 이유는 insertImageAtCursor 메서드에서 새로운 이미지를 받아와 contentEditText에 반영하지 않고 있었기 때문입니다.
따라서 insertImageAtCursor 메서드에서 새로운 이미지를 contentEditText에 반영하고, 객체 치환 문자를 삽입합니다.
convertToHtmlStyledContent에서는 새롭게 반영된 이미지를 객체 치환 문자로 찾음으로써 새로운 이미지를 인식하고 이를 img 태그로 변환하여 해결하였습니다.
- 참고로, convertToHtmlStyledContent는 기존, 업데이트, 삭제 이미지에 대한 정보가 전부 반영된 imageData을 활용하여 게시글을 html로 변경합니다.
- 기존에 uploadNewImagesToStorage()와 uploadNewFilesToStorage()는 업데이트 이미지가 없다면 실행되지 않게 설계되었는데,
이 경우, 기존에 존재하는 이미지와 파일을 imageData에 추가하는 로직이 이 위 두 메서드에 반영되어있기 때문에 업데이트 이미지와 무관하게 실행되고 하고, 업데이트 이미지의 존재유무는 위 두 메서드들 내부에서 처리하도록 로직을 변경하여 imageData에 대한 무결성을 보장하였습니다.
2. 추가적으로, 이미지들의 position들을 리스트로 관리하였는데, 기존 이미지와 업데이트 이미지의 position은 게시글이 변경됨에 따라 유동적입니다.
- 즉, 업데이트 이미지를 기존 이미지에 앞선 위치에 반영한다거나 기존 이미지 앞선 위치에 텍스트를 반영하면 이미지들의 위치를 리스트에서 변경해줘야 합니다. 
- afterTextChanged()로 텍스트의 변경을 인식하고, updateImagePositions() 메서드를 실행하여 변경된 이미지의 위치들을 반영하는 방식으로 해결하였습니다.

### 스크린샷 (선택)
### 삭제 UI
![KakaoTalk_20250105_021215312](https://github.com/user-attachments/assets/d9a3f412-51a0-41a8-a091-7dee01060a3c)

## 리뷰 요구사항 (선택)

1, 현재 보기모드에서는 스크롤 기능이 비활성화 되어있습니다. 게시글이 휴대폰 사이즈를 넘어가게되면 스크롤 기능을 활성화할 필요가 있습니다.
2. 추가로 이미지가 추가되면서 게시글을 저장하거나 로드하는데 시간이 오래 걸립니다. 이 문제에 대해서는 추후에 해결할 필요가 있습니다.
