### PR TITLE
메인페이지 캘린더 영역 완료

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="ssary">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/app/src/main/java/com/example/ssary/MainActivity.java
+++ b/app/src/main/java/com/example/ssary/MainActivity.java
@@ -1,27 +1,34 @@
-// MainActivity.java
 package com.example.ssary;
 
 import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.Typeface;
 import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.DisplayMetrics;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.View;
-import android.widget.CalendarView;
 import android.widget.FrameLayout;
+import android.widget.GridLayout;
+import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import androidx.viewpager2.widget.ViewPager2;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
-import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -37,66 +44,249 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        // ViewPager2와 Adapter 설정
         recruitViewPager = findViewById(R.id.recruit_view_pager);
-        mainJobAdapter = new MainJobAdapter(jobList);  // 초기에는 빈 jobList로 설정
+        mainJobAdapter = new MainJobAdapter(jobList);
         recruitViewPager.setAdapter(mainJobAdapter);
 
-        // Firebase에서 채용 공고 데이터를 불러오기
         loadJobDataFromFirebase();
 
-        // 첫 번째 공간 클릭 시 이동
         FrameLayout firstSection = findViewById(R.id.first_section);
         firstSection.setOnClickListener(view -> {
             Intent intent = new Intent(MainActivity.this, MainActivity.class);
             startActivity(intent);
         });
 
-        // 캘린더 이동 버튼 클릭 시
         TextView calendarButton = findViewById(R.id.calendar_button);
         calendarButton.setOnClickListener(view -> {
             Intent intent = new Intent(MainActivity.this, CalendarActivity.class);
             startActivity(intent);
         });
 
-        // 다이어리 이동 버튼 클릭 시
         TextView diaryButton = findViewById(R.id.diary_button);
         diaryButton.setOnClickListener(view -> {
             Intent intent = new Intent(MainActivity.this, MyPageActivity.class);
             startActivity(intent);
         });
 
-        // 채용 공고 이동 버튼 클릭 시
         TextView recruitButton = findViewById(R.id.recruit_button);
         recruitButton.setOnClickListener(view -> {
             Intent intent = new Intent(MainActivity.this, JobActivity.class);
             startActivity(intent);
         });
 
-        // CalendarView 이벤트 설정
-        CalendarView calendarView = findViewById(R.id.calendar_view);
-        calendarView.setOnDateChangeListener((view, year, month, dayOfMonth) -> {
-            String date = year + "/" + (month + 1) + "/" + dayOfMonth;
-            Toast.makeText(MainActivity.this, "선택한 날짜: " + date, Toast.LENGTH_SHORT).show();
+        // 커스텀 달력 세팅
+        setupCustomCalendar();
+        loadTodaySchedules();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        setupCustomCalendar();
+        loadTodaySchedules();
+    }
+
+
+
+
+    private void setupCustomCalendar() {
+        TextView monthYearText = findViewById(R.id.month_year_text);
+        GridLayout calendarLayout = findViewById(R.id.custom_calendar);
+        TextView scheduleHeader = findViewById(R.id.schedule_header);
+
+        calendarLayout.removeAllViews();
+
+        DisplayMetrics dm = getResources().getDisplayMetrics();
+        int screenWidthPx = dm.widthPixels;
+
+        int dayViewHorizontalPadding = (int) (screenWidthPx * 0.015f);
+        int dayViewVerticalPadding   = (int) (screenWidthPx * 0.008f);
+
+        Calendar calendar = Calendar.getInstance();
+        int year = calendar.get(Calendar.YEAR);
+        int month = calendar.get(Calendar.MONTH) + 1;
+        int today = calendar.get(Calendar.DAY_OF_MONTH);
+
+        monthYearText.setText(year + "년 " + month + "월");
+
+        SimpleDateFormat sdf = new SimpleDateFormat("M월 d일 EEEE", Locale.KOREAN);
+        scheduleHeader.setText(sdf.format(calendar.getTime()));
+
+        String[] daysOfWeek = {"S", "M", "T", "W", "T", "F", "S"};
+        for (String day : daysOfWeek) {
+            TextView dayView = new TextView(this);
+            dayView.setText(day);
+            dayView.setGravity(Gravity.CENTER);
+            dayView.setTypeface(null, Typeface.BOLD);
+            // 여기서 퍼센트 기반 패딩 적용
+            dayView.setPadding(dayViewHorizontalPadding, dayViewVerticalPadding,
+                    dayViewHorizontalPadding, dayViewVerticalPadding);
+
+            calendarLayout.addView(dayView);
+        }
+
+        calendar.set(Calendar.DAY_OF_MONTH, 1);
+        int firstDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
+        int daysInMonth = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
+
+        for (int i = 1; i < firstDayOfWeek; i++) {
+            TextView emptyView = new TextView(this);
+            emptyView.setText("");
+            calendarLayout.addView(emptyView);
+        }
+
+        for (int day = 1; day <= daysInMonth; day++) {
+            TextView dateView = new TextView(this);
+            dateView.setText(String.valueOf(day));
+            dateView.setGravity(Gravity.CENTER);
+
+            // 날짜 셀에도 퍼센트 기반 패딩 적용
+            dateView.setPadding(dayViewHorizontalPadding, dayViewVerticalPadding,
+                    dayViewHorizontalPadding, dayViewVerticalPadding);
+
+            if (day == today) {
+                dateView.setBackground(ContextCompat.getDrawable(this, R.drawable.circle_background));
+                dateView.setTextColor(Color.WHITE);
+            }
+            calendarLayout.addView(dateView);
+        }
+    }
+
+    private void loadTodaySchedules() {
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user == null) {
+            return;
+        }
+        String uid = user.getUid();
+
+        Calendar calendar = Calendar.getInstance();
+        String dateKey = createValidDateKey(
+                calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH) + 1,
+                calendar.get(Calendar.DAY_OF_MONTH)
+        );
+
+        DatabaseReference scheduleRef = FirebaseDatabase.getInstance()
+                .getReference("schedule")
+                .child(uid)
+                .child(dateKey);
+
+        scheduleRef.orderByChild("order").addListenerForSingleValueEvent(new ValueEventListener() {
+            @Override
+            public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
+                LinearLayout scheduleContentArea = findViewById(R.id.schedule_content_area);
+
+                scheduleContentArea.removeAllViews();
+
+                // 데이터가 없으면 "오늘 일정이 없습니다." TextView를 새로 만들어 붙임
+                if (!dataSnapshot.exists() || dataSnapshot.getChildrenCount() == 0) {
+                    TextView noDataTV = new TextView(MainActivity.this);
+                    noDataTV.setText("오늘 일정이 없습니다.");
+                    noDataTV.setTextColor(Color.parseColor("#888888"));
+                    noDataTV.setGravity(Gravity.CENTER);
+                    noDataTV.setPadding(0, 16, 0, 16);
+                    scheduleContentArea.addView(noDataTV);
+                    return;
+                }
+
+                int count = 0;
+
+                for (DataSnapshot snapshot : dataSnapshot.getChildren()) {
+                    String content = snapshot.child("content").getValue(String.class);
+                    if (content == null) continue;
+
+                    // 최대 4개의 스케줄만 표시
+                    if (count == 4) {
+                        TextView moreView = new TextView(MainActivity.this);
+                        moreView.setText("...");
+                        moreView.setTextSize(16f);
+                        moreView.setTypeface(null, Typeface.BOLD);
+                        moreView.setPadding(0, 8, 0, 8);
+                        scheduleContentArea.addView(moreView);
+                        break;
+                    }
+
+                    // (1) 스케줄 한 줄 레이아웃
+                    LinearLayout scheduleItemLayout = new LinearLayout(MainActivity.this);
+                    scheduleItemLayout.setOrientation(LinearLayout.HORIZONTAL);
+                    scheduleItemLayout.setGravity(Gravity.CENTER_VERTICAL);
+                    // 너비 match_parent, 높이 wrap_content
+                    LinearLayout.LayoutParams itemParams = new LinearLayout.LayoutParams(
+                            LinearLayout.LayoutParams.MATCH_PARENT,
+                            LinearLayout.LayoutParams.WRAP_CONTENT
+                    );
+                    scheduleItemLayout.setLayoutParams(itemParams);
+                    // 조금의 세로 여백
+                    scheduleItemLayout.setPadding(0, 8, 0, 8);
+
+                    // (2) 파란 네모박스
+                    View blueBox = new View(MainActivity.this);
+                    // 16dp -> px 변환
+                    int boxSize = (int) (16 * getResources().getDisplayMetrics().density);
+
+                    LinearLayout.LayoutParams boxParams = new LinearLayout.LayoutParams(boxSize, boxSize);
+                    // 박스와 텍스트 사이 가로 간격
+                    boxParams.setMarginEnd(8);
+
+                    blueBox.setLayoutParams(boxParams);
+                    blueBox.setBackground(ContextCompat.getDrawable(MainActivity.this, R.drawable.square_blue));
+                    blueBox.setPadding(0, 2, 0, 0);
+
+                    // (3) 내용 TextView
+                    TextView contentView = new TextView(MainActivity.this);
+                    contentView.setLayoutParams(
+                            new LinearLayout.LayoutParams(
+                                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                                    LinearLayout.LayoutParams.WRAP_CONTENT
+                            )
+                    );
+                    contentView.setText(content);
+                    contentView.setTextSize(16f);
+                    contentView.setTextColor(Color.BLACK);
+                    contentView.setPadding(0, 0, 0, 2);
+
+                    // 긴 내용일 경우 한 줄만 표시 + ... 처리
+                    contentView.setSingleLine(true);
+                    contentView.setEllipsize(TextUtils.TruncateAt.END);
+
+                    // (4) scheduleItemLayout에 순서대로 추가
+                    scheduleItemLayout.addView(blueBox);
+                    scheduleItemLayout.addView(contentView);
+
+                    // (5) schedule_content_area에 추가
+                    scheduleContentArea.addView(scheduleItemLayout);
+
+                    count++;
+                }
+            }
+
+            @Override
+            public void onCancelled(@NonNull DatabaseError databaseError) {
+                // ...
+            }
         });
+    }
+
+
+
+    private String createValidDateKey(int year, int month, int day) {
+        return String.format("%d_%02d_%02d", year, month, day);
     }
 
     private void loadJobDataFromFirebase() {
         DatabaseReference databaseReference = FirebaseDatabase.getInstance().getReference("JOB");
-        String todayDate = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(new Date());
-
         databaseReference.addValueEventListener(new ValueEventListener() {
             @Override
             public void onDataChange(@NonNull DataSnapshot dataSnapshot) {
                 jobList.clear();
-                Date today = new Date();
+                Date now = new Date();
 
                 for (DataSnapshot snapshot : dataSnapshot.getChildren()) {
                     Job job = snapshot.getValue(Job.class);
                     if (job != null) {
                         try {
                             Date endDate = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(job.getEndDate());
-                            if (endDate != null && endDate.after(today)) { // 마감일이 오늘 이후인 공고만 추가
+                            if (endDate != null && endDate.after(now)) {
                                 jobList.add(job);
                             }
                         } catch (ParseException e) {
@@ -105,12 +295,10 @@ public class MainActivity extends AppCompatActivity {
                     }
                 }
 
-                // 최대 4개의 공고만 표시
                 if (jobList.size() > 4) {
                     jobList = jobList.subList(0, 4);
                 }
 
-                // ViewPager 및 "공고 없음" 메시지 제어
                 ViewPager2 recruitViewPager = findViewById(R.id.recruit_view_pager);
                 TextView noJobsText = findViewById(R.id.no_jobs_text);
 
@@ -122,7 +310,6 @@ public class MainActivity extends AppCompatActivity {
                     noJobsText.setVisibility(View.GONE);
                 }
 
-                // 어댑터 설정
                 mainJobAdapter = new MainJobAdapter(jobList);
                 recruitViewPager.setAdapter(mainJobAdapter);
             }
@@ -133,6 +320,4 @@ public class MainActivity extends AppCompatActivity {
             }
         });
     }
-
-
 }

--- a/app/src/main/res/drawable/bg_shape_no_padding.xml
+++ b/app/src/main/res/drawable/bg_shape_no_padding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="12dp"/>
+    <solid android:color="@android:color/white"/>
+    <!-- padding이나 inset은 전혀 두지 않음 -->
+</shape>

--- a/app/src/main/res/drawable/circle_background.xml
+++ b/app/src/main/res/drawable/circle_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#007AFF" />
+
+    <size
+        android:width="24dp"
+        android:height="24dp" />
+
+</shape>

--- a/app/src/main/res/drawable/square_blue.xml
+++ b/app/src/main/res/drawable/square_blue.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="4dp"/>
+    <stroke
+        android:width="2dp"
+        android:color="#007AFF"/>
+    <solid android:color="@android:color/white"/>
+
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true"> <!-- 전체 화면을 차지하도록 설정 -->
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -11,7 +11,7 @@
         android:orientation="vertical"
         android:padding="16dp">
 
-        <!-- 첫 번째 공간 (클릭 가능한 공간) -->
+        <!-- 첫 번째 공간 (변경 없음) -->
         <FrameLayout
             android:id="@+id/first_section"
             android:layout_width="match_parent"
@@ -19,8 +19,7 @@
             android:background="@drawable/bg_shape"
             android:clickable="true"
             android:focusable="true"
-            android:contentDescription="싸피 소식"
-            android:layout_marginBottom="10dp"/>
+            android:layout_marginBottom="10dp" />
 
         <!-- 두 번째 공간 (캘린더) -->
         <LinearLayout
@@ -29,11 +28,11 @@
             android:orientation="vertical"
             android:layout_marginBottom="10dp">
 
+            <!-- 캘린더 제목과 버튼 (기존 그대로) -->
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-                <!-- 캘린더 제목 -->
                 <TextView
                     android:id="@+id/calendar_title"
                     android:layout_width="wrap_content"
@@ -43,44 +42,103 @@
                     android:textStyle="bold"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"/>
+                    app:layout_constraintBottom_toBottomOf="parent" />
 
-                <!-- 이동하기 버튼 -->
                 <TextView
                     android:id="@+id/calendar_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:clickable="true"
                     android:text="이동하기"
                     android:textColor="#007AFF"
                     android:padding="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"/>
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:clickable="true" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <!-- 캘린더 뷰 추가 -->
-            <FrameLayout
-                android:id="@+id/second_section"
+            <!-- ConstraintLayout으로 퍼센트 지정 -->
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="200dp"
+                android:layout_height="wrap_content"
                 android:background="@drawable/bg_shape"
                 android:layout_marginTop="8dp">
 
-                <!-- CalendarView를 공간 절반 정도 크기로 설정 -->
-                <CalendarView
-                    android:id="@+id/calendar_view"
-                    android:layout_width="200dp"
-                    android:layout_height="190dp"
-                    android:layout_gravity="center"
-                    android:layout_margin="8dp"
-                    android:layout_weight="1"
-                    android:maxHeight="250dp"
-                    android:minHeight="150dp" />
-            </FrameLayout>
+                <!-- 왼쪽(캘린더) 영역: width_percent="0.6" (기존 동일) -->
+                <LinearLayout
+                    android:id="@+id/calendar_container"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="8dp"
+                    app:layout_constraintWidth_percent="0.6"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent">
+
+                    <TextView
+                        android:id="@+id/month_year_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:gravity="center"
+                        android:layout_marginBottom="8dp"
+                        android:text="연/월" />
+
+                    <GridLayout
+                        android:id="@+id/custom_calendar"
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:layout_weight="1"
+                        android:columnCount="7" />
+                </LinearLayout>
+
+                <!-- 오른쪽(스케줄) 부분만 레이아웃 수정 -->
+                <LinearLayout
+                    android:id="@+id/schedule_list_container"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:orientation="vertical"
+                    android:padding="8dp"
+
+                    app:layout_constraintWidth_percent="0.4"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent">
+
+                    <!-- (1) 상단 날짜 텍스트 (고정) -->
+                    <TextView
+                        android:id="@+id/schedule_header"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:layout_marginBottom="8dp"
+                        android:gravity="center"
+                        android:text="오늘 날짜" />
+
+                    <!-- (2) 아래쪽 스크롤 영역 -->
+                    <ScrollView
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:fillViewport="true">
+
+                        <LinearLayout
+                            android:id="@+id/schedule_content_area"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical">
+
+                            <!-- 향후 일정 목록(동적 추가) 가능 -->
+                        </LinearLayout>
+                    </ScrollView>
+                </LinearLayout>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </LinearLayout>
 
-        <!-- 세 번째 공간 (다이어리) -->
+        <!-- 세 번째 공간 (다이어리) (변경 없음) -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -91,7 +149,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-                <!-- 다이어리 제목 -->
                 <TextView
                     android:id="@+id/diary_title"
                     android:layout_width="wrap_content"
@@ -103,7 +160,6 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toBottomOf="parent"/>
 
-                <!-- 이동하기 버튼 -->
                 <TextView
                     android:id="@+id/diary_button"
                     android:layout_width="wrap_content"
@@ -125,7 +181,7 @@
                 android:layout_marginTop="8dp"/>
         </LinearLayout>
 
-        <!-- 네 번째 공간 (채용 공고) -->
+        <!-- 네 번째 공간 (채용 공고) (변경 없음) -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -136,7 +192,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-                <!-- 채용 공고 제목 -->
                 <TextView
                     android:id="@+id/recruit_title"
                     android:layout_width="wrap_content"
@@ -148,7 +203,6 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toBottomOf="parent"/>
 
-                <!-- 이동하기 버튼 -->
                 <TextView
                     android:id="@+id/recruit_button"
                     android:layout_width="wrap_content"
@@ -162,7 +216,6 @@
                     app:layout_constraintBottom_toBottomOf="parent"/>
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <!-- 채용 공고 ViewPager2 -->
             <androidx.viewpager2.widget.ViewPager2
                 android:id="@+id/recruit_view_pager"
                 android:layout_width="match_parent"


### PR DESCRIPTION
## 연관된 이슈

#44 메인페이지 캘린더 영역 구현

## 작업 내용

- 좌측 미니 달력 구현(금일 파란 동그라미 표시)
- 우측 스케줄(4개) 불러오기
- 사용자마다 저장된 금일 스케줄 불러오기
- 스케줄이 일정 길이 넘어갈 경우 ...처리

## 트러블 슈팅

1. 뒤로가기로 다시 메인페이지 접근 시 변경사항 미반영
- 문제점 : 캘린더 페이지에 접근하여 금일 일정 추가, 수정, 삭제 후 뒤로가기로 메인페이지 접근 시 반영 안됨
- 해결 : onResume 메서드를 생성하여 뒤로가기로 메인페이지 다시 접근 시 변경 사항 반영

### 스크린샷 (선택)

<table>
  <tr>
    <td>스케줄 없을 경우</td>
    <td>스케줄 여러 개일 경우</td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/06ded6df-59e6-4519-adda-c96547f07930" width="300"></td>
    <td><img src="https://github.com/user-attachments/assets/e6950a8d-14bc-4788-b4b3-4f5aeb88b8c5" width="300"></td>
  </tr>
</table>
