### PR TITLE
이미지 삽입 기능 버그 해결

### DIFF
--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -52,6 +52,7 @@ import com.google.firebase.storage.StorageReference;
 import java.net.URL;
 import java.text.BreakIterator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +91,6 @@ public class MyExistTextActivity extends AppCompatActivity {
     private final List<Uri> updatedImageUris = new ArrayList<>();
     private final List<String> updatedImageNames = new ArrayList<>();
     private final List<Integer> updatedImagePositions = new ArrayList<>();
-
 
     private final List<Uri> existedFileUris = new ArrayList<>();
     private final List<String> existedFileExtensions = new ArrayList<>();
@@ -312,24 +312,27 @@ public class MyExistTextActivity extends AppCompatActivity {
 
     // 이미지 삭제 대화상자 표시 메서드
     private void showDeleteImageDialog(Uri imageUri) {
-        new AlertDialog.Builder(this)
+        AlertDialog dialog = new AlertDialog.Builder(this)
                 .setTitle("이미지 삭제")
                 .setMessage("해당 이미지를 삭제하시겠습니까?")
-                .setPositiveButton("삭제", (dialog, which) -> deleteImage(imageUri))
-                .setNegativeButton("취소", (dialog, which) -> {
-                    // 취소 시 즉시 undo 실행
+                .setPositiveButton("삭제", (dialogInterface, which) -> deleteImage(imageUri))
+                .setNegativeButton("취소", (dialogInterface, which) -> {
                     if (undoRedoManager.canUndo()) {
                         isUndoRedoAction = true;
                         UndoRedoManager.State previousState = undoRedoManager.undo();
-
-                        // 상태 복원
                         restoreState(previousState);
-
                         isUndoRedoAction = false;
                     }
                     updateUndoRedoButtons();
                 })
-                .show();
+                .create();
+
+        // 다이얼로그가 외부 터치나 뒤로가기 버튼으로 닫히지 않도록 설정
+        dialog.setCancelable(false);
+        dialog.setCanceledOnTouchOutside(false);
+
+        // 다이얼로그 표시
+        dialog.show();
     }
 
     private void deleteImage(Uri imageUri) {

--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -191,10 +191,11 @@ public class MyExistTextActivity extends AppCompatActivity {
             public void afterTextChanged(Editable s) {
                 updateImagePositions(s);
 
-                if (deletedImageSpan != null) {
+                // Undo/Redo 중이 아니고 이미지 삭제 액션일 때만 다이얼로그 호출
+                if (deletedImageSpan != null && !isUndoRedoAction) {
                     Uri imageUri = Uri.parse(deletedImageSpan.getSource());
                     showDeleteImageDialog(imageUri);
-                    deletedImageSpan = null; // 초기화
+                    deletedImageSpan = null;
                 }
 
                 if (!isUndoRedoAction && !isInitialAccess) {

--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -379,7 +379,7 @@ public class MyExistTextActivity extends AppCompatActivity {
             Editable text = contentEditText.getText();
 
             // 객체 치환 문자 삽입
-            text.insert(position, "\uFFFC");
+            text.insert(position, " ");
             ImageSpan imageSpan = new ImageSpan(drawable, imageUri.toString(), ImageSpan.ALIGN_BASELINE);
             text.setSpan(imageSpan, position, position + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
@@ -1248,25 +1248,28 @@ public class MyExistTextActivity extends AppCompatActivity {
         int currentIndex = 0; // 텍스트의 현재 위치
         int imageIndex = 0;   // 이미지 데이터의 현재 인덱스
 
-        while (currentIndex < text.length() || imageIndex < imageData.size()) {
-            if (imageIndex < imageData.size()) {
-                // 텍스트에서 객체 치환 문자("\uFFFC")를 찾음
-                if (currentIndex < text.length() && text.charAt(currentIndex) == '\uFFFC') {
-                    // 이미지 URL 삽입
+        ImageSpan[] imageSpans = text.getSpans(0, text.length(), ImageSpan.class);
+
+        while (currentIndex < text.length()) {
+            boolean imageProcessed = false;
+
+            for (ImageSpan imageSpan : imageSpans) {
+                int start = text.getSpanStart(imageSpan);
+                int end = text.getSpanEnd(imageSpan);
+
+                if (currentIndex == start) {
                     String imageUrl = imageData.get(imageIndex).get("imageUrl");
-                    if (imageUrl != null && !imageUrl.isEmpty()) {
+                    if (imageUrl != null) {
                         htmlContent.append("<img src=\"").append(imageUrl).append("\" />");
                     }
-
-                    // 다음 이미지로 이동
+                    currentIndex = end;
                     imageIndex++;
-                    currentIndex++;
-                    continue;
+                    imageProcessed = true;
+                    break;
                 }
             }
 
-            // 일반 텍스트 처리
-            if (currentIndex < text.length()) {
+            if (!imageProcessed) {
                 char ch = text.charAt(currentIndex++);
                 if (ch == '\n') {
                     htmlContent.append("<br>");

--- a/app/src/main/java/com/example/ssary/MyExistTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyExistTextActivity.java
@@ -404,7 +404,8 @@ public class MyExistTextActivity extends AppCompatActivity {
                     new SpannableString(contentEditText.getText()),
                     curImageUris,
                     curImageNames,
-                    curImagePositions
+                    curImagePositions,
+                    contentEditText.getSelectionStart()
             ));
 
             updateUndoRedoButtons();
@@ -432,7 +433,7 @@ public class MyExistTextActivity extends AppCompatActivity {
         manageDeletedAndExistedImages(state);
 
         // 커서 위치 조정
-        contentEditText.setSelection(state.text.length());
+        contentEditText.setSelection(state.cursorPosition);
     }
 
     // Undo & Redo 시, 이미지 삭제 및 추가 메서드
@@ -704,7 +705,8 @@ public class MyExistTextActivity extends AppCompatActivity {
                     (Spannable) styledText,
                     curImageUris,
                     curImageNames,
-                    curImagePositions
+                    curImagePositions,
+                    contentEditText.getSelectionStart()
             ));
         } else {
             Spannable spannableText = new SpannableString(styledText);
@@ -712,7 +714,8 @@ public class MyExistTextActivity extends AppCompatActivity {
                     spannableText,
                     curImageUris,
                     curImageNames,
-                    curImagePositions
+                    curImagePositions,
+                    contentEditText.getSelectionStart()
             ));
         }
 

--- a/app/src/main/java/com/example/ssary/MyNewTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyNewTextActivity.java
@@ -297,11 +297,6 @@ public class MyNewTextActivity extends AppCompatActivity {
         imageNames.addAll(initialImageNames);
         imagePositions.addAll(initialImagePositions);
 
-        // 이미지를 텍스트에 삽입
-        for (int i = 0; i < imageUris.size(); i++) {
-            insertImageAtPosition(imageUris.get(i), imagePositions.get(i));
-        }
-
         // UndoRedoManager에 초기 상태 저장
         undoRedoManager.saveState(new UndoRedoManager.State(
                 new SpannableString(""),
@@ -385,34 +380,9 @@ public class MyNewTextActivity extends AppCompatActivity {
         imageNames.addAll(state.imageNames);
         imagePositions.addAll(state.imagePositions);
 
-        // UI에서 이미지 재삽입
-        for (int i = 0; i < imageUris.size(); i++) {
-            insertImageAtPosition(imageUris.get(i), imagePositions.get(i));
-        }
-
         // 커서 위치 조정
-        contentEditText.setSelection(state.text.length());
+        contentEditText.setSelection(state.cursorPosition);
     }
-
-
-    private void insertImageAtPosition(Uri imageUri, int position) {
-        try {
-            Drawable drawable = Drawable.createFromStream(
-                    getContentResolver().openInputStream(imageUri),
-                    null
-            );
-            assert drawable != null;
-            drawable.setBounds(0, 0, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
-
-            Editable text = contentEditText.getText();
-            ImageSpan imageSpan = new ImageSpan(drawable, ImageSpan.ALIGN_BASELINE);
-            text.insert(position, " "); // 이미지 자리 확보
-            text.setSpan(imageSpan, position, position + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-        } catch (Exception e) {
-            Toast.makeText(this, "이미지를 복원할 수 없습니다.", Toast.LENGTH_SHORT).show();
-        }
-    }
-
 
     // DB로 부터 카테고리 목록을 가져오는 메서드
     private void loadCategoriesFromDB() {

--- a/app/src/main/java/com/example/ssary/MyNewTextActivity.java
+++ b/app/src/main/java/com/example/ssary/MyNewTextActivity.java
@@ -302,7 +302,8 @@ public class MyNewTextActivity extends AppCompatActivity {
                 new SpannableString(""),
                 imageUris,
                 imageNames,
-                imagePositions
+                imagePositions,
+                contentEditText.getSelectionStart()
         ));
 
         updateUndoRedoButtons(); // 초기 버튼 상태 업데이트
@@ -356,7 +357,8 @@ public class MyNewTextActivity extends AppCompatActivity {
                     new SpannableString(contentEditText.getText()),
                     imageUris,
                     imageNames,
-                    imagePositions
+                    imagePositions,
+                    contentEditText.getSelectionStart()
             ));
 
             updateUndoRedoButtons();

--- a/app/src/main/java/com/example/ssary/ui/theme/UndoRedoManager.java
+++ b/app/src/main/java/com/example/ssary/ui/theme/UndoRedoManager.java
@@ -2,6 +2,8 @@ package com.example.ssary.ui.theme;
 
 import android.net.Uri;
 import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,12 +16,14 @@ public class UndoRedoManager {
         public List<Uri> imageUris;
         public List<String> imageNames;
         public List<Integer> imagePositions;
+        public int cursorPosition;
 
-        public State(Spannable text, List<Uri> imageUris, List<String> imageNames, List<Integer> imagePositions) {
+        public State(Spannable text, List<Uri> imageUris, List<String> imageNames, List<Integer> imagePositions, int cursorPosition) {
             this.text = text;
             this.imageUris = new ArrayList<>(imageUris);
             this.imageNames = new ArrayList<>(imageNames);
             this.imagePositions = new ArrayList<>(imagePositions);
+            this.cursorPosition = cursorPosition;
         }
 
         @Override
@@ -77,6 +81,14 @@ public class UndoRedoManager {
         return nextState; // 다음 상태 반환
     }
 
+    public CharSequence getCurrentStateText() {
+        if (!undoStack.isEmpty()) {
+            if (undoStack.peek().text instanceof SpannableStringBuilder) {
+                return undoStack.peek().text;
+            } else {
+                return (SpannableString) undoStack.peek().text;
+            }
+        }
+        return null;
+    }
 }
-
-


### PR DESCRIPTION
## 연관된 이슈

> #20 

## 작업 내용

> 이미지 삽입 로직 수행 과정 중 잦은 오류와 버그가 발견되어 이를 순차적으로 해결하였습니다.
> 이미지 삭제에 대한 삭제 확인 다이얼로그는 백스페이스로 이미지를 삭제했을 때만 나오고, undo을 사용했을 때는 나오지 않게 설계하였습니다. 따라서 undo을 수행했을 때 다이얼로그가 나오지 않는 것이 오류가 아님을 알립니다.
> 자세한 과정은 트러블 슈팅 란을 확인해주세요!

## 트러블 슈팅


### 1. [기존 게시글] undo 실행 시, 다이얼로그 뜨는 오류
- undo와 redo 실행에 대한 불리언을 설정하여, 삭제 이미지에 대한 확인 다이얼로그 로직에 추가함으로써 해결하였습니다.

### 2. [기존 게시글] undo 실행 시, 객체 치환 문자 등장
- 기존 게시글에서는 새로운 이미지를 추가했을 때, 객체 치환 문자를 추가함으로써 글 저장 시 html로 변경해주는 과정에서 이 객체 치환 문자를 인식하여 이미지를 삽입하는 기능을 활용했었습니다.
- 이때 문제는 undo 스택에 이 객체 치환 문자가 저장되는 문제로 인해서 undo 실행 시 이 객체 치환 문자가 그대로 UI에 노출되는 문제가 발생하였습니다.
- 따라서 새로운 이미지 삽입 시 객체 치환 문자 대신에 imageSpan을 활용하여 해당 위치에 이미지가 추가되었음을 표시하였고, 이를 html로 변경하는 과정에 사용하여 문제를 해결하였습니다.

### 3. [새 게시글] 백스페이스로 삭제 시, 다이얼로그 뜨게 구현
- 기존 게시글에 있던 백스페이스 다이얼로그 기능을 새 게시글에도 추가하였습니다.

### 4. [새 게시글] 이미지 위치를 텍스트가 변경됨에 따라 계속 업데이트할 수 있는 로직 추가
- 기존 게시글에 적용했던 이미치 위치 업데이트 메서드를 새 게시글에도 추가함으로써 텍스트가 변경됨에 따라 이미지의 위치가 업데이트될 수 있도록 하였습니다.

### 5. [새 게시글] undo & redo 실행 시, 이미지가 중복으로 삽입되는 오류 해결
- 이미지를 수동으로 삽입하던 insertImageAtPosition 메서드를 삭제함으로써 해결하였습니다.

### 6. [새/기존 게시글] undo & redo 실행 시, 커서를 undo 또는 redo 수행 위치에 위치시키기
- undo 또는 redo을 수행할 때, 커서의 위치가 항상 게시글 상단에 고정되게끔 되어있던 것을 수정 위치에 위치할 수 있도록 수정하였습니다.
- 이를 위해서는 위치를 항상 저장하고 있어야하기 때문에 UndoRedoManager.java 클래스에 cursorPosition을 추가하여 수정 위치를 항상 저장하여 사용할 수 있도록 하였습니다.

### 7. [새/기존 게시글] undo & redo 실행 시, "커서 강조" 때문에 두 번 눌러야 그 전 글이나 다음 글이 나옴 - IME(입력기)
- 기본적으로 "커서 강조" 효과는 IME(입력기) 문제로 입력 중인 문자가 완전히 확정되지 않은 상태로, IME(Input Method Editor)에서 해당 글자를 임시로 처리하고 있는 상태를 나타냅니다.
- 예를 들어서 "안녕하세요"를 입력한 다음 "안녕하세요오"을 입력했을 때 커서 강조 효과가 "요"에 있을 때 "안녕하세요"를 스택에 저장하고, 오를 입력했을 때 커서 강조는 "오"에 존재하기 때문에 커서 강조가 없는 "안녕하세요"를 또 스택에 저장하는 문제가 발생합니다. 즉, "안녕하세요(커서강조)"와 "안녕하세요"를 다르게 인식하여 둘다 스택에 저장합니다. 이 경우 undo 버튼을 1번 눌렀을 때 "안녕하세요"가 나오고, 2번 눌렀을 때 "안녕하세요(커서강조)"가 나오기 때문에 결국 사용자 입장에서는 "안녕하세요"가 두 번 등장하는 상황이 발생하게 되는 것입니다.
- UndoRedoManager.java 클래스에 getCurrentStateText() 메서드를 추가함으로써 현재 텍스트와 스택에 저장된 텍스트를 비교하여 같은 경우 스택에 중복으로 저장되지 않도록 함으로써 해결하였습니다.

### 8. [새/기존 게시글] 다이얼로그가 나왔을 때, 화면을 터치하면 꺼져서 삭제 이미지가 리스트에 포함되지 않아 오류가 발생
- 다이얼로그가 외부 터치나 뒤로가기 버튼으로 닫히지 않도록 설정함으로써 다이얼로그의 질문에 대한 답변의 강제성을 부여하여 해결하였습니다.

## 리뷰 요구사항 (선택)

> 1. 텍스트 스타일도 UndoRedoManager.java 클래스에 저장하여 기능할 수 있도록 수정해야합니다. - 정수 파트

> 2. 보기 모드에서 스크롤이 가능하도록 수정해야합니다. - 화정 파트

> 3. 가존 게시글에서 이미지를 다운로드 받을 수 있는 기능도 넣으면 좋을거 같습니다.

> 4. 이전에 이야기한 이미지 삽입과 파일 삽입 시 저장 시간과 로드 시간이 오래 걸립니다. 이를 염두해두고 추후에 수정하여야 합니다.

> 5. MyNewTextActivity.java와 MyExistTextActivity.java의 클래스 분리가 시급합니다. 이 두 클래스 파일의 코드가 방대해짐에 따라 유지보수가 힘들어짐을 감안했을 때, 추후 기능에 따라 클래스를 분리할 필요가 있습니다.
